### PR TITLE
Validation for \KrameWork\Mailing\EncodedContent::setEncoding()

### DIFF
--- a/docs/Mailing/EncodedContent.md
+++ b/docs/Mailing/EncodedContent.md
@@ -47,7 +47,7 @@ parameter | type | description
 `$content` | `string` | Content data.
 ##### > hasContent() : `bool`
 Check if this container has content.
-##### > setEncoding() : `void`
+##### > setEncoding() : `bool`
 Set the encoding of this content.
 
 parameter | type | description

--- a/src/Mailing/EncodedContent.php
+++ b/src/Mailing/EncodedContent.php
@@ -72,9 +72,16 @@
 		 *
 		 * @api setEncoding
 		 * @param string $encoding Encoding to use for this content.
+		 * @return bool
 		 */
-		public function setEncoding(string $encoding) {
+		public function setEncoding(string $encoding):bool{
+			if ($encoding !== self::E_7BIT && $encoding !== self::E_BASE64 && $encoding !== self::E_QUOTED_PRINTABLE) {
+				return false;
+			}
+
 			$this->encoding = $encoding;
+
+			return true;
 		}
 
 		/**


### PR DESCRIPTION
Not really a huge thing, as the __toString() method will silently ignore invalid values anyway.