### PR TITLE
Better dispatching of core errors

### DIFF
--- a/src/Runtime/ErrorDispatchers/BufferDispatcher.php
+++ b/src/Runtime/ErrorDispatchers/BufferDispatcher.php
@@ -36,7 +36,7 @@
 	 * @package KrameWork\Runtime\ErrorDispatchers
 	 * @author Kruithne <kruithne@gmail.com>
 	 */
-	class BufferDispatcher implements IErrorDispatcher
+	class BufferDispatcher implements IErrorDispatcher, IBufferDispatcher
 	{
 		/**
 		 * Dispatch an error report.

--- a/src/Runtime/ErrorDispatchers/IBufferDispatcher.php
+++ b/src/Runtime/ErrorDispatchers/IBufferDispatcher.php
@@ -1,0 +1,38 @@
+<?php
+	/*
+	 * Copyright (c) 2017 Kruithne (kruithne@gmail.com)
+	 * https://github.com/Kruithne/KrameWork7
+	 *
+	 * Permission is hereby granted, free of charge, to any person obtaining a copy
+	 * of this software and associated documentation files (the "Software"), to deal
+	 * in the Software without restriction, including without limitation the rights
+	 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+	 * copies of the Software, and to permit persons to whom the Software is
+	 * furnished to do so, subject to the following conditions:
+	 *
+	 * The above copyright notice and this permission notice shall be included in all
+	 * copies or substantial portions of the Software.
+	 *
+	 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+	 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+	 * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+	 * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+	 * SOFTWARE.
+	 */
+
+	namespace Kramework\Runtime\ErrorDispatchers;
+	use KrameWork\Runtime\ErrorReports\IErrorReport;
+
+	/**
+	 * Interface IErrorDispatcher
+	 * Represents classes in charge of dispatching error reports via writing to the PHP output buffer.
+	 * This is used to tag dispatchers that cannot be used during core error handling.
+	 *
+	 * @package Kramework\Runtime\ErrorDispatchers
+	 * @author docpify <morten@runsafe.no>
+	 */
+	interface IBufferDispatcher
+	{
+	}


### PR DESCRIPTION
Enable the use of MailDispatchers with Core errors when a core error formatter is defined even though a BufferDispatcher is added for non-core error handling.